### PR TITLE
Fixed direction info

### DIFF
--- a/src/main/java/net/darkhax/infoaccessories/info/InfoType.java
+++ b/src/main/java/net/darkhax/infoaccessories/info/InfoType.java
@@ -99,7 +99,11 @@ public enum InfoType {
 
     private static void addDirectionInfo (World world, EntityPlayer player, List<String> info) {
 
-        final int yaw = MathHelper.floor(player.rotationYaw % 360.0F);
+        int yaw = MathHelper.floor(player.rotationYaw % 360.0F);
+
+        if (yaw < 0) {
+            yaw += 360;
+        }
 
         for (final IntercardinalDirection direction : IntercardinalDirection.values()) {
 


### PR DESCRIPTION
`player.rotationYaw` can be negative, while this will always yield a number whose absolute value is less than 360, its sign depends on the summed absolute rotation since spawning, meaning if the player has turned more leftwards than rightwards the value will be negative.

This leads to the info showing "Direction: S (-x)" with a negative value for x.

It's easily fixed by adding 360 to the yaw if it is negative.